### PR TITLE
refactor: centralize screen geometry and tighten widget typing

### DIFF
--- a/src/core/main_controller.py
+++ b/src/core/main_controller.py
@@ -18,7 +18,7 @@ from widgets.thought_bubble import ThoughtBubble
 from utils.utils import (
     STATE_FILE, RANKING_FILE, ACHIEVEMENTS,
     xp_for_level, is_achievement_met, validate_state,
-    load_json_safe, save_json_safe,
+    load_json_safe, save_json_safe, screen_geometry,
     EATS_UNTIL_POOP, POOP_SPAWN_CHANCE, RANDOM_EVENT_CHANCE,
     CPU_HIGH_THRESHOLD, MAX_KIRBYS, BREEDING_DISTANCE,
     BREED_COOLDOWN_FRAMES, POOP_CLEAN_XP, BREED_XP, STAR_FIND_XP,
@@ -419,7 +419,7 @@ class MainController:
             return
         self._breed_cooldown = BREED_COOLDOWN_FRAMES
 
-        screen = QApplication.primaryScreen().geometry()
+        screen = screen_geometry()
         max_x = screen.width() - BABY_SPAWN_MARGIN
         max_y = screen.height() - BABY_SPAWN_MARGIN
         mid_x = max(0, min(max_x, (parent_a.pos().x() + parent_b.pos().x()) / 2))

--- a/src/dialogs/ranking_board.py
+++ b/src/dialogs/ranking_board.py
@@ -71,8 +71,11 @@ class RankingBoard(QDialog):
         # Clear existing
         while self._content_layout.count():
             item = self._content_layout.takeAt(0)
-            if item.widget():
-                item.widget().deleteLater()
+            if item is None:
+                break
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
 
         if not ranking:
             empty = QLabel("No ranking data yet.\nStart playing!")

--- a/src/utils/particles.py
+++ b/src/utils/particles.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 import random
 
-from PyQt5.QtWidgets import QWidget, QApplication
+from PyQt5.QtWidgets import QWidget
 from PyQt5.QtGui import QPainter, QColor, QFont, QPaintEvent
 from PyQt5.QtCore import Qt, QTimer, QPointF
 
@@ -13,6 +13,7 @@ from utils.macos_window import pin_window_above_mission_control
 from utils.utils import (
     PARTICLE_GRAVITY, PARTICLE_DECAY_RANGE, PARTICLE_TICK_MS, MAX_PARTICLES,
     PARTICLE_SPEED_RANGE, PARTICLE_UPWARD_BOOST, PARTICLE_MIN_LIFE,
+    screen_geometry,
 )
 
 
@@ -89,7 +90,7 @@ class ParticleOverlay(QWidget):
         )
         self.setAttribute(Qt.WA_TranslucentBackground)
         self.setAttribute(Qt.WA_TransparentForMouseEvents)
-        screen = QApplication.primaryScreen().geometry()
+        screen = screen_geometry()
         self.setGeometry(screen)
         self._particles: list[Particle] = []
 

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -7,7 +7,10 @@ import logging
 import math
 import os
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from PyQt5.QtCore import QRect
 
 __version__ = "2.4.0"
 
@@ -270,6 +273,25 @@ def validate_state(state: Any) -> dict[str, Any]:
         a for a in achievements if isinstance(a, str) and a in valid_ids
     ]
     return cleaned
+
+
+def screen_geometry() -> "QRect":
+    """Return the primary screen's geometry.
+
+    Wraps ``QApplication.primaryScreen()``, which is typed as optional and
+    can be ``None`` when no display is attached. In that case a zero-sized
+    ``QRect`` is returned so callers never crash on ``None.geometry()``.
+
+    Returns:
+        The primary screen geometry, or an empty ``QRect`` if unavailable.
+    """
+    from PyQt5.QtCore import QRect
+    from PyQt5.QtWidgets import QApplication
+
+    screen = QApplication.primaryScreen()
+    if screen is None:
+        return QRect()
+    return screen.geometry()
 
 
 def resource_path(relative_path: str) -> str:

--- a/src/widgets/pet_widget.py
+++ b/src/widgets/pet_widget.py
@@ -7,12 +7,12 @@ import random
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Optional
 
-from PyQt5.QtWidgets import QLabel, QWidget, QApplication
+from PyQt5.QtWidgets import QLabel, QWidget
 from PyQt5.QtGui import QMovie
 from PyQt5.QtCore import Qt, QTimer, QPointF
 
 from utils.utils import (
-    resource_path,
+    resource_path, screen_geometry,
     PET_FPS, PET_MAX_SPEED, PET_CHASE_MAX_SPEED, PET_ACCELERATION,
     PET_FRICTION, PET_THROW_FRICTION, PET_THROW_GRAVITY,
     PET_FLIP_SPEED_THRESHOLD, PET_THROW_STOP_SPEED,
@@ -60,8 +60,8 @@ class PetWidget(QWidget):
 
         # Drag state
         self._dragging = False
-        self._drag_offset: Optional[QPointF] = None
-        self._drag_positions: list[tuple] = []
+        self._drag_offset: Optional[QPoint] = None
+        self._drag_positions: list[tuple[QPoint, int]] = []
 
         # Physics
         self._max_speed = BABY_MAX_SPEED if is_baby else PET_MAX_SPEED
@@ -95,7 +95,7 @@ class PetWidget(QWidget):
         self.label.setScaledContents(True)
         self.label.resize(self._current_movie.frameRect().size())
 
-        screen = QApplication.primaryScreen().geometry()
+        screen = screen_geometry()
         self._screen_width = screen.width()
         self._screen_height = screen.height()
 

--- a/src/widgets/snack_widget.py
+++ b/src/widgets/snack_widget.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import random
 from typing import Optional, Tuple
 
-from PyQt5.QtWidgets import QLabel, QWidget, QApplication
+from PyQt5.QtWidgets import QLabel, QWidget
 from PyQt5.QtGui import QFont
 from PyQt5.QtCore import Qt
 
-from utils.utils import FOODS, SNACK_SPAWN_MARGIN
+from utils.utils import FOODS, SNACK_SPAWN_MARGIN, screen_geometry
 from utils.macos_window import pin_window_above_mission_control
 
 FoodDef = Tuple[str, str, int, int]  # (emoji, name, hunger_restore, xp_reward)
@@ -35,7 +35,7 @@ class SnackWidget(QWidget):
         self.label.adjustSize()
         self.resize(self.label.size())
 
-        screen = QApplication.primaryScreen().geometry()
+        screen = screen_geometry()
         max_x = screen.width() - self.width() - SNACK_SPAWN_MARGIN
         max_y = screen.height() - self.height() - SNACK_SPAWN_MARGIN
         x = random.randint(SNACK_SPAWN_MARGIN, max(SNACK_SPAWN_MARGIN, max_x))

--- a/src/widgets/thought_bubble.py
+++ b/src/widgets/thought_bubble.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from PyQt5.QtWidgets import QWidget, QApplication
+from PyQt5.QtWidgets import QWidget
 from PyQt5.QtGui import QPainter, QColor, QFont, QPainterPath, QPaintEvent
 from PyQt5.QtCore import Qt, QTimer, QRectF
 
 from utils.macos_window import pin_window_above_mission_control
-from utils.utils import FADE_TICK_MS
+from utils.utils import FADE_TICK_MS, screen_geometry
 
 _OPACITY_THRESHOLD = 0.01
 _FADE_RATE = 0.15
@@ -49,7 +49,7 @@ class ThoughtBubble(QWidget):
         self._hide_timer.setSingleShot(True)
         self._hide_timer.timeout.connect(self.fade_out)
 
-        self._screen = QApplication.primaryScreen().geometry()
+        self._screen = screen_geometry()
         self.show()
         pin_window_above_mission_control(self)
 


### PR DESCRIPTION
## What changed

Small, surgical, behavior-preserving cleanups to the `src/` code only (no assets, no gameplay changes):

- **`utils.screen_geometry()` helper.** `QApplication.primaryScreen()` is typed `Optional[QScreen]` and is genuinely `None` when no display is attached, so `QApplication.primaryScreen().geometry()` could crash with `AttributeError`. Added a single helper that returns a zero-sized `QRect` in that case, and replaced the **5 duplicated call sites** (`PetWidget`, `SnackWidget`, `ThoughtBubble`, `ParticleOverlay`, breeding spawn). Removed the now-unused `QApplication` imports those files no longer needed.
- **`pet_widget.py` typing.** `_drag_offset` was annotated `Optional[QPointF]` but the runtime value is a `QPoint` (`event.globalPos() - self.pos()`); corrected to `Optional[QPoint]`. Tightened `_drag_positions: list[tuple]` to `list[tuple[QPoint, int]]`.
- **`ranking_board.py` row clearing.** Cache `item.widget()` in a local instead of calling it twice, and guard the optional layout item / widget when clearing rows.

## Why behavior-preserving

- `screen_geometry()` returns exactly `primaryScreen().geometry()` whenever a screen exists (the only path that runs on a real desktop); the `None` branch is a new safety net for the previously-crashing headless case, not a behavior change in normal use.
- The `_drag_offset`/`_drag_positions` edits are annotation-only — no runtime change (`QPoint` is what was always stored).
- The ranking-row clearing keeps identical semantics: the `while count()` loop already guaranteed a non-`None` item, and a missing/`None` widget was already skipped; the change just avoids a duplicate `widget()` call and is `None`-safe.

## Verification

Python 3.12 venv, deps from `pyproject.toml`, tools `ruff`/`pyright`/`pytest`.

| Check | Before | After |
|-------|--------|-------|
| `ruff check src tests scripts` | pass | pass |
| `pytest` | 158 passed | 158 passed |
| `scripts/smoke_headless.py` (offscreen) | 19 checks | 19 checks |
| `pyright src` | 58 errors | 50 errors |

All 8 resolved pyright errors were the real `reportOptionalMemberAccess` ones (5x `geometry` on `None`, 3x layout-item/widget on `None`). The remaining 50 are PyQt5/pyobjc stub false positives only: Qt enum attribute access (e.g. `Qt.AlignCenter`) and `paintEvent`/`mouse*Event` override param-name `a0` vs `event`. All changed modules import cleanly under offscreen Qt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)