### PR TITLE
docs: align README with the working project

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ python3 -m pytest
 ### Technical
 - **Mission Control compatible** — Kirby stays visible during F3, Spaces, and full-screen apps
 - **Menu bar tray icon** — All controls live in the macOS menu bar. Left-click to feed, right-click for full menu
-- **Particle system** — Full-screen transparent overlay with eat, heart, sleep, level-up, sweat, and achievement effects
+- **Particle system** — Full-screen transparent overlay with eat, heart, achievement, level-up, sleep, sweat, and poop effects
 - **Thought bubbles** — Kirby tells you what he's thinking with smooth fade-in/out
 - **Named tuning constants** — Gameplay, physics, and timing values are named and centralized in `utils.py`
 - **Fully type-annotated** — Every public function carries parameter and return type hints
@@ -133,7 +133,7 @@ coding-with-kirby/
 │   │   └── ranking_board.py       # Leaderboard with auto-refresh
 │   └── utils/
 │       ├── utils.py               # All constants, validators, JSON I/O
-│       ├── particles.py           # Full-screen particle overlay (6 presets)
+│       ├── particles.py           # Full-screen particle overlay (eat, heart, achievement, level-up, sleep, sweat, poop)
 │       └── macos_window.py        # Cocoa window pinning for Mission Control
 ├── tests/
 │   ├── test_utils.py              # Constants, validators, JSON I/O


### PR DESCRIPTION
## Summary

Audited the README against the actual code. The README is overall accurate and complete — install/build/run/test commands, project structure, features, achievement count (9), test count (158), license (MIT), and gameplay constants (30s autosave, 60s sleep, CPU 80%, max 6 Kirbys, etc.) all match the source.

One inaccuracy fixed: the particle-system descriptions.

## Corrections
- **Project Structure:** `particles.py` was annotated `(6 presets)`. The code has 4 named entries in `_PRESETS` (eat, heart, achievement, level_up) plus 3 inline emit effects (sleep, sweat, poop) — 7 distinct effects total. Replaced the misleading count with the actual effect list.
- **Technical / Particle system:** the effect list omitted `poop` (a real emitter used by the poop system) and is now complete.

No features were invented; only the particle-effect wording was corrected to match `src/utils/particles.py`.